### PR TITLE
Remove s variable and remove nltk log messages

### DIFF
--- a/gptrim/gptrim.py
+++ b/gptrim/gptrim.py
@@ -5,10 +5,8 @@ import nltk
 from nltk.corpus import stopwords
 from nltk.stem import PorterStemmer, SnowballStemmer, LancasterStemmer
 
-nltk.download('punkt')
-nltk.download('stopwords')
-
-s = "But don’t humans also have genuinely original ideas?” Come on, read a fantasy book. It’s either a Tolkien clone, or it’s A Song Of Ice And Fire. Tolkien was a professor of Anglo-Saxon language and culture; no secret where he got his inspiration. A Song Of Ice And Fire is just War Of The Roses with dragons. Lannister and Stark are just Lancaster and York, the map of Westeros is just Britain (minus Scotland) with an upside down-Ireland stuck to the bottom of it – wake up, sheeple! Dullards blend Tolkien into a slurry and shape it into another Tolkien-clone. Tolkien-level artistic geniuses blend human experience, history, and the artistic corpus into a slurry and form it into an entirely new genre. Again, the difference is how finely you blend and what spices you add to the slurry."
+nltk.download('punkt', quiet=True)
+nltk.download('stopwords', quiet=True)
 
 ARTICLES_PREPOSITIONS = {
     "english": ['the', 'a', 'an', 'in', 'on', 'at', 'for', 'to', 'of']


### PR DESCRIPTION
- The variable s with an example string is not needed in the package
- Added the option to quiet=True to the nltk.download calls to reduce the messages printed to the log